### PR TITLE
Add auto-deploy via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy Frontend
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+            cd ~/dev/portfolio-website-nextjs
+            git fetch origin main
+            git reset --hard origin/main
+            npm ci
+            npx next build
+            pm2 restart portfolio-website
+            pm2 restart portfolio-backend


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that auto-deploys on push to `main`
- SSHes into the server, pulls latest code, rebuilds, and restarts the frontend via PM2
- Also restarts the backend to trigger ChromaDB embedding sync for any new blog posts

## Test plan
- [ ] Merge to main and verify GitHub Actions workflow runs successfully
- [ ] Verify the frontend is rebuilt and serving the latest content
- [ ] Verify backend restarts and syncs any new blog post embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)