### PR TITLE
Fix peer dependency conflict: downgrade @chakra-ui/icons to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zen-saha",
+  "name": "portfolio-website-nextjs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "@chakra-ui/icons": "^2.1.1",
+        "@chakra-ui/icons": "^1.1.7",
         "@chakra-ui/react": "^1.8.9",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
@@ -371,27 +371,17 @@
       }
     },
     "node_modules/@chakra-ui/icons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.1.tgz",
-      "integrity": "sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-1.1.7.tgz",
+      "integrity": "sha512-YIHxey/B4M2PyFASlHXtAWFyW+tsAtGAChOJ8dsM2kpu1MbVUqm/6nMI1KIFd7Te5IWuNYA75rAHBdLI0Yu61A==",
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/icon": "3.2.0"
+        "@chakra-ui/icon": "2.0.5",
+        "@types/react": "^17.0.15"
       },
       "peerDependencies": {
-        "@chakra-ui/system": ">=2.0.0",
-        "react": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/icons/node_modules/@chakra-ui/icon": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
-      "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
-      "dependencies": {
-        "@chakra-ui/shared-utils": "2.0.5"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=2.0.0",
-        "react": ">=18"
+        "@chakra-ui/system": ">=1.0.0",
+        "react": ">=16.8.6"
       }
     },
     "node_modules/@chakra-ui/image": {
@@ -748,11 +738,6 @@
         "@chakra-ui/system": ">=1.0.0",
         "react": ">=16.8.6"
       }
-    },
-    "node_modules/@chakra-ui/shared-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
-      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
     },
     "node_modules/@chakra-ui/skeleton": {
       "version": "1.2.14",
@@ -1566,25 +1551,29 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.67",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.67.tgz",
-      "integrity": "sha512-vkIE2vTIMHQ/xL0rgmuoECBCkZFZeHr49HeWSc24AptMbNRo7pwSBvj73rlJJs9fGKj0koS+V7kQB1jHS0uCgw==",
-      "dev": true,
+      "version": "17.0.91",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+      "integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.2.2"
       }
+    },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@chakra-ui/icons": "^2.1.1",
+    "@chakra-ui/icons": "^1.1.7",
     "@chakra-ui/react": "^1.8.9",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",


### PR DESCRIPTION
## Summary
- Downgrade `@chakra-ui/icons` from v2 to v1 to match the project's Chakra UI v1 setup
- Fixes `npm ci` failure in the deploy workflow caused by `@chakra-ui/icons@2.1.1` requiring `@chakra-ui/system >=2.0.0`
- All 4 icons used (`ArrowForwardIcon`, `ExternalLinkIcon`, `ArrowLeftIcon`, `ArrowRightIcon`) exist in v1

## Test plan
- [x] `npm ci` succeeds locally with clean `node_modules/`
- [x] `next build` completes successfully
- [ ] Deploy workflow passes without `npm ERR! ERESOLVE` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)