### PR TITLE
SEO: Add canonical URLs to all pages

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,14 +1,19 @@
 import { Flex } from "@chakra-ui/react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import NavBar from "./NavBar";
 import Footer from "./Footer";
 import { colors } from "../lib/constants";
 
 export default function Layout({ title, description, children, ...flexProps }) {
+  const router = useRouter();
+  const canonicalUrl = `https://irtizahafiz.com${router.asPath.split("?")[0]}`;
+
   return (
     <Flex bg={colors.bgPrimary} flexDirection="column" {...flexProps}>
       <Head>
         <title>{title}</title>
+        <link rel="canonical" href={canonicalUrl} />
         {description && (
           <meta name="description" content={description} key="desc" />
         )}

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -88,13 +88,17 @@ const components = {
 
 export default function PostPage({
   frontMatter: { title, description, seoTitle, seoDescription, tags },
+  slug,
   mdxSource,
   selectedRelatedPosts,
 }) {
+  const canonicalUrl = `https://irtizahafiz.com/blog/${slug}`;
+
   return (
     <Flex bg={colors.bgPrimary} flexDirection="column" color="white">
       <Head>
         <title>{title}</title>
+        <link rel="canonical" href={canonicalUrl} />
         <meta name="title" content={seoTitle}></meta>
         <meta name="description" content={seoDescription}></meta>
         <meta


### PR DESCRIPTION
## Summary
- Add `<link rel="canonical">` to the Layout component (covers homepage, credit-cards, programming, tools, newsletter)
- Add `<link rel="canonical">` to blog post pages using the slug
- Prevents duplicate content issues in search indexing

## Test plan
- [x] Build succeeds
- [x] Homepage renders `<link rel="canonical" href="https://irtizahafiz.com/">`
- [x] Blog post renders `<link rel="canonical" href="https://irtizahafiz.com/blog/{slug}">`
- [ ] Verify in production via View Source

🤖 Generated with [Claude Code](https://claude.com/claude-code)