### PR TITLE
SEO: Add JSON-LD structured data to blog posts

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -87,12 +87,21 @@ const components = {
 };
 
 export default function PostPage({
-  frontMatter: { title, description, seoTitle, seoDescription, tags },
+  frontMatter: { title, description, seoTitle, seoDescription, tags, date },
   slug,
   mdxSource,
   selectedRelatedPosts,
 }) {
   const canonicalUrl = `https://irtizahafiz.com/blog/${slug}`;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: title,
+    description: description,
+    author: { "@type": "Person", name: "Irtiza Hafiz" },
+    datePublished: date,
+    url: canonicalUrl,
+  };
 
   return (
     <Flex bg={colors.bgPrimary} flexDirection="column" color="white">
@@ -108,6 +117,10 @@ export default function PostPage({
         <meta property="og:title" content={title}></meta>
         <meta property="og:description" content={description}></meta>
         <meta property="og:type" content="article"></meta>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
       </Head>
       <NavBar />
       <Flex flexDirection={"column"}>


### PR DESCRIPTION
## Summary
- Add `BlogPosting` schema.org JSON-LD markup to all blog post pages
- Fields sourced from existing MDX frontmatter: title, description, date, slug
- Enables rich snippets (author, date, description) in Google search results
- No visual changes to the page

## Test plan
- [x] Build succeeds
- [x] JSON-LD renders correctly in page source with all fields populated
- [ ] Validate with https://search.google.com/test/rich-results after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)