### PR TITLE
Perf: Lazy-load syntax highlighter (442KB → 162KB)

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -3,7 +3,11 @@ import { MDXRemote } from "next-mdx-remote";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import SyntaxHighlighter from "react-syntax-highlighter";
+import dynamic from "next/dynamic";
+
+const SyntaxHighlighter = dynamic(() => import("react-syntax-highlighter"), {
+  loading: () => <pre>Loading...</pre>,
+});
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";


### PR DESCRIPTION
## Summary
- Dynamically import `react-syntax-highlighter` so the 901KB (uncompressed) bundle only loads on blog posts that use code blocks
- Blog page First Load JS reduced from **442KB to 162KB**
- Non-code blog posts (credit cards, travel) no longer load the syntax highlighting library at all

## Test plan
- [x] Build succeeds
- [x] All blog post pages return 200
- [ ] Verify code blocks render correctly on programming posts in production
- [ ] Verify non-code posts load faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)