### PR TITLE
Analytics: consolidate umami events + newsletter interest picker

### DIFF
--- a/components/Banner.js
+++ b/components/Banner.js
@@ -48,7 +48,8 @@ export default function Banner() {
             <Link
               href="/programming"
               passHref
-              data-umami-event="banner-programming-cta-click"
+              data-umami-event="Banner CTA Click"
+              data-umami-event-section="programming"
             >
               <Text
                 as="span"
@@ -63,7 +64,8 @@ export default function Banner() {
             <Link
               href="/credit-cards"
               passHref
-              data-umami-event="banner-credit-cards-cta-click"
+              data-umami-event="Banner CTA Click"
+              data-umami-event-section="credit-cards"
             >
               <Text
                 as="span"

--- a/components/BlogCard.js
+++ b/components/BlogCard.js
@@ -45,7 +45,8 @@ export default function BlogCard({ post }) {
         </Text>
         <Link
           href={`/blog/${postSlug}`}
-          data-umami-event="blog-card-cta-clicked"
+          data-umami-event="Blog Card Click"
+          data-umami-event-post={postSlug}
         >
           <Heading
             color={colors.accentGreen}
@@ -62,7 +63,8 @@ export default function BlogCard({ post }) {
         <Spacer />
         <Link
           href={`/blog/${postSlug}`}
-          data-umami-event="blog-card-cta-clicked"
+          data-umami-event="Blog Card Click"
+          data-umami-event-post={postSlug}
         >
           <Button bg={colors.accentYellow} color={colors.textDark} size="sm">
             Read More

--- a/components/BookConsultationButton.js
+++ b/components/BookConsultationButton.js
@@ -4,7 +4,7 @@ import { colors, CONSULTATION_URL } from "../lib/constants";
 export default function BookConsultationButton() {
   const handleClick = () => {
     try {
-      umami.track("free-consultation-button-click");
+      umami.track("Consultation Click");
     } catch (error) {
       console.log(error);
     }

--- a/components/Categories.js
+++ b/components/Categories.js
@@ -15,7 +15,8 @@ export default function Categories({ categories }) {
             key={category.slug}
             href={`/${category.slug}`}
             passHref
-            data-umami-event={`category-${category.slug}-cta-click`}
+            data-umami-event="Category Click"
+            data-umami-event-category={category.slug}
           >
             <Box
               bg="white"

--- a/components/CreditCardItem.js
+++ b/components/CreditCardItem.js
@@ -13,8 +13,7 @@ export default function CreditCardItem({
   const handleClick = (e) => {
     e.preventDefault();
     try {
-      umami.track("credit-card-apply-clicked");
-      umami.track(`${cardName}-apply-clicked`);
+      umami.track("Credit Card Apply", { card: cardName });
     } catch (error) {
       console.log(error);
     }
@@ -40,7 +39,7 @@ export default function CreditCardItem({
         </Text>
         <Spacer />
 
-        <Link href={referralURL} data-umami-event={`${cardName}-apply-clicked`}>
+        <Link href={referralURL}>
           <Button
             bg={colors.accentYellow}
             color={colors.textDark}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -28,7 +28,7 @@ export default function NavBar() {
       <Flex align="center" display={["none", "flex"]}>
         <Link
           href="/"
-          data-umami-event="Home Tab Selected"
+          data-umami-event="Logo Click"
           fontSize="xl"
           fontWeight="bold"
         >
@@ -49,7 +49,11 @@ export default function NavBar() {
           direction={["row", "row", "row", "row"]}
           paddingTop={[4, 0, 0, 0]}
         >
-          <Link href="/" data-umami-event="Home Tab Selected">
+          <Link
+            href="/"
+            data-umami-event="Nav Tab Click"
+            data-umami-event-tab="home"
+          >
             <Text
               fontSize={{ base: "xs", md: "lg" }}
               color="white"
@@ -59,7 +63,11 @@ export default function NavBar() {
               Home
             </Text>
           </Link>
-          <Link href="/programming" data-umami-event="Programming Tab Selected">
+          <Link
+            href="/programming"
+            data-umami-event="Nav Tab Click"
+            data-umami-event-tab="programming"
+          >
             <Text
               color="white"
               fontSize={{ base: "xs", md: "lg" }}
@@ -71,7 +79,8 @@ export default function NavBar() {
           </Link>
           <Link
             href="/credit-cards"
-            data-umami-event="Credit Card Tab Selected"
+            data-umami-event="Nav Tab Click"
+            data-umami-event-tab="credit-cards"
           >
             <Text
               color="white"
@@ -83,7 +92,11 @@ export default function NavBar() {
               Credit Cards
             </Text>
           </Link>
-          <Link href="/newsletter" data-umami-event="Newsletter Tab Selected">
+          <Link
+            href="/newsletter"
+            data-umami-event="Nav Tab Click"
+            data-umami-event-tab="newsletter"
+          >
             <Text
               color="white"
               fontSize={{ base: "xs", md: "lg" }}
@@ -93,7 +106,11 @@ export default function NavBar() {
               Newsletter
             </Text>
           </Link>
-          <Link href="/tools" data-umami-event="Tools Tab Selected">
+          <Link
+            href="/tools"
+            data-umami-event="Nav Tab Click"
+            data-umami-event-tab="tools"
+          >
             <Text
               color="white"
               fontSize={{ base: "xs", md: "lg" }}

--- a/components/SmartSearch.js
+++ b/components/SmartSearch.js
@@ -48,8 +48,7 @@ export default function SmartSearch({
       console.error("Network error:", error.message);
     }
     try {
-      umami.track("smart-search-btn-click");
-      umami.track(`${searchQueryText}-SMART-SEARCH`);
+      umami.track("Smart Search", { query: searchQueryText?.slice(0, 100) });
     } catch (error) {
       console.log(error);
     }

--- a/components/SubscribeForm.js
+++ b/components/SubscribeForm.js
@@ -6,6 +6,9 @@ import {
   FormLabel,
   Input,
   FormHelperText,
+  RadioGroup,
+  Radio,
+  Stack,
   useToast,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
@@ -15,13 +18,14 @@ import { colors, API_NEWSLETTER_URL, NEWSLETTER_LIST_UUID } from "../lib/constan
 export default function SubscribeForm() {
   const [firstName, setFirstName] = useState("");
   const [emailAddress, setEmailAddress] = useState("");
+  const [interest, setInterest] = useState("");
   const successToast = useToast();
   const failureToast = useToast();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      umami.track("Subscribe Clicked");
+      umami.track("Subscribe Click", { interest });
     } catch (error) {
       console.log(error);
     }
@@ -41,6 +45,7 @@ export default function SubscribeForm() {
       });
       setFirstName("");
       setEmailAddress("");
+      setInterest("");
     } catch (error) {
       failureToast({
         title: "Oops!",
@@ -83,13 +88,22 @@ export default function SubscribeForm() {
             hidden={true}
           />
         </FormControl>
+        <FormControl isRequired>
+          <FormLabel>What are you interested in?</FormLabel>
+          <RadioGroup value={interest} onChange={setInterest}>
+            <Stack direction={["column", "row"]} spacing="1.5vw">
+              <Radio value="credit-cards">Credit Cards</Radio>
+              <Radio value="software-development">Software Development</Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
         <VStack>
           <FormControl>
             <Button
               bg={colors.accentYellow}
               color={colors.textDark}
               size="lg"
-              isDisabled={!(firstName && emailAddress)}
+              isDisabled={!(firstName && emailAddress && interest)}
               type="submit"
             >
               Subscribe

--- a/components/YouTubeHorizontalCarousel.js
+++ b/components/YouTubeHorizontalCarousel.js
@@ -13,7 +13,7 @@ export default function YouTubeHorizontalCarousel({ youtubeVideos }) {
         href={YOUTUBE_CHANNEL_URL}
         target="_blank"
         passHref
-        data-umami-event="youtube-carousel-channel-cta-clicked"
+        data-umami-event="YouTube Channel Click"
       >
         <Text
           as="span"

--- a/components/YoutubeCard.js
+++ b/components/YoutubeCard.js
@@ -31,7 +31,8 @@ export default function YoutubeCard({ videoData }) {
       <Link
         href={`https://youtube.com/watch?v=${videoData?.snippet?.resourceId?.videoId}`}
         target="_blank"
-        data-umami-event="youtube-carousel-card-cta-clicked"
+        data-umami-event="YouTube Video Click"
+        data-umami-event-video={videoData?.snippet?.title}
       >
         <Button bg={colors.accentYellow} color={colors.textDark} size="sm">
           Watch Video

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -41,6 +41,7 @@ export const CONTENT_CATEGORY = {
 
 // Credit card data for the carousel
 export const creditCards = [
+  // AMEX personal
   {
     imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-gold.png`,
     cardName: "American Express Gold",
@@ -48,34 +49,18 @@ export const creditCards = [
     referralKey: "amexGold",
   },
   {
+    imageURL: `${CDN_BASE_URL}/credit-cards-photos/hilton-surpass.png`,
+    cardName: "Hilton Surpass Card",
+    cardDescription: "12X Hilton Purchases! 6X Restaurants, Groceries, & Gas! 130K Bonus Points!",
+    referralKey: "amexHiltonSurpass",
+  },
+
+  // Capital One personal
+  {
     imageURL: `${CDN_BASE_URL}/venture-x.png`,
     cardName: "Capital One Venture X",
     cardDescription: "Unlimited 2X miles! Lounge Access! 75K Bonus Miles! $300 Travel Credit! 10K Anniversary Bonus!",
     referralKey: "capitalOneVentureX",
-  },
-  {
-    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-business-gold.png`,
-    cardName: "American Express Business Gold",
-    cardDescription: "4X on Cloud & Software Spend, Tech Gadgets, Advertising, Gas, Transit! 100K Bonus Points!",
-    referralKey: "amexBusinessGold",
-  },
-  {
-    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-blue-business-plus.png`,
-    cardName: "AMEX Blue Business Plus",
-    cardDescription: "15K Bonus Points! 2X Points on Everything!",
-    referralKey: "amexBlueBusinessPlus",
-  },
-  {
-    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-business-platinum.png`,
-    cardName: "American Express Business Platinum",
-    cardDescription: "5X on Flights! $3,500+ in credits! Lounge Access! 200K Bonus Points!",
-    referralKey: "amexBusinessPlatinum",
-  },
-  {
-    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-platinum-delta-business.png`,
-    cardName: "American Express Delta Platinum Business",
-    cardDescription: "3X on Delta Purchases! Free Companion Certificate! 70K Bonus Miles!",
-    referralKey: "amexDeltaPlatinumBusiness",
   },
   {
     imageURL: `${CDN_BASE_URL}/credit-cards-photos/savor-one.png`,
@@ -83,17 +68,13 @@ export const creditCards = [
     cardDescription: "3X Restaurants, Groceries & Entertainment! $300 Bonus!",
     referralKey: "capitalOneSavorRewards",
   },
+
+  // Other personal
   {
     imageURL: `${CDN_BASE_URL}/credit-cards-photos/sapphire_preferred.png`,
     cardName: "Chase Sapphire Preferred",
     cardDescription: "3X Dining, 2X Travel, 60K Bonus Points! $50 Travel Credit!",
     referralKey: "chaseSapphirePreferred",
-  },
-  {
-    imageURL: `${CDN_BASE_URL}/credit-cards-photos/hilton-surpass.png`,
-    cardName: "Hilton Surpass Card",
-    cardDescription: "12X Hilton Purchases! 6X Restaurants, Groceries, & Gas! 130K Bonus Points!",
-    referralKey: "amexHiltonSurpass",
   },
   {
     imageURL: `${CDN_BASE_URL}/credit-cards-photos/freedom_flex.png`,
@@ -118,5 +99,31 @@ export const creditCards = [
     cardName: "Citi Strata Elite",
     cardDescription: "12X Points on Hotels! 6X on Flights! 1.5X Everything else! 100K Bonus Points!",
     referralKey: "citiStrataElite",
+  },
+
+  // Business
+  {
+    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-business-gold.png`,
+    cardName: "American Express Business Gold",
+    cardDescription: "4X on Cloud & Software Spend, Tech Gadgets, Advertising, Gas, Transit! 100K Bonus Points!",
+    referralKey: "amexBusinessGold",
+  },
+  {
+    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-blue-business-plus.png`,
+    cardName: "AMEX Blue Business Plus",
+    cardDescription: "15K Bonus Points! 2X Points on Everything!",
+    referralKey: "amexBlueBusinessPlus",
+  },
+  {
+    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-business-platinum.png`,
+    cardName: "American Express Business Platinum",
+    cardDescription: "5X on Flights! $3,500+ in credits! Lounge Access! 200K Bonus Points!",
+    referralKey: "amexBusinessPlatinum",
+  },
+  {
+    imageURL: `${CDN_BASE_URL}/credit-cards-photos/amex-platinum-delta-business.png`,
+    cardName: "American Express Delta Platinum Business",
+    cardDescription: "3X on Delta Purchases! Free Companion Certificate! 70K Bonus Miles!",
+    referralKey: "amexDeltaPlatinumBusiness",
   },
 ];

--- a/lib/referralLinks.js
+++ b/lib/referralLinks.js
@@ -18,10 +18,10 @@ const referralLinks = {
     "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/cards/business/vanity/bluebusinessplus-credit-card?CORID=M~D~I~R~T~H~c~y~i~n-1764206443910-993651&GENCODE=349993340941547&XLINK=MYCP&extlink=US-MGM-SPA_WEB_MYCA-copypaste-1110-201329-K44D%3A9951&ref=MDIRTHcyin&v=2&xrefer=bluebusinessplus-credit-card",
 
   amexBusinessPlatinum:
-    "https://americanexpress.com/en-us/referral/business-platinum-charge-card?ref=MDIRTHgkN1&xl=cp15",
+    "https://americanexpress.com/en-us/referral/business-platinum-charge-card?ref=MDIRTHmHuC&xl=cp15",
 
   amexDeltaPlatinumBusiness:
-    "https://americanexpress.com/en-us/referral/delta-skymiles-platinum?ref=MDIRTHiGzB&xl=cp15",
+    "https://americanexpress.com/en-us/referral/delta-skymiles-platinum?ref=MDIRTHUCti&xl=cp15",
 
   amexHiltonSurpass:
     "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/cards/personal/vanity/bluebusinessplus-credit-card?CORID=M~D~I~R~T~H~c~y~i~n-1764206443910-993651&GENCODE=349993340941547&XLINK=MYCP&extlink=US-MGM-SPA_WEB_MYCA-copypaste-1110-201329-K44D%3A9951&ref=MDIRTHcyin&v=2&xrefer=bluebusinessplus-credit-card",
@@ -45,9 +45,9 @@ const referralLinks = {
 
   chaseSapphireReserve: "https://www.referyourchasecard.com/19u/P69MUTKHKM",
 
-  chaseFreedomFlex: "https://www.referyourchasecard.com/18d/SV19LJ9X7A",
+  chaseFreedomFlex: "https://www.referyourchasecard.com/18m/YDDY4YLY93",
 
-  chaseFreedomUnlimited: "https://www.referyourchasecard.com/18d/SV19LJ9X7A",
+  chaseFreedomUnlimited: "https://www.referyourchasecard.com/18m/YDDY4YLY93#flex-content",
 
   chaseIHGPremier: "https://www.referyourchasecard.com/210y/U1YREPZMZM",
 

--- a/pages/tools.js
+++ b/pages/tools.js
@@ -7,8 +7,7 @@ import { colors } from "../lib/constants";
 export default function Tools({ tools }) {
   const handleLinkClick = (toolName) => {
     try {
-      umami.track("tool-clicked");
-      umami.track(`${toolName}-clicked`);
+      umami.track("Tool Click", { tool: toolName });
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
## Summary

- **Newsletter interest picker**: required radio group (Credit Cards / Software Development) on the subscribe form; selection is attached to the CTA event, **not** persisted to Listmonk.
- **Umami event consolidation**: every tracked click now uses a single Title Case event name with a structured `{ property }` payload so the dashboard stops sprawling and per-card/per-tab/per-category metrics become drilldowns instead of distinct event names.
- **Broken referral links**: refreshed URLs for Amex Business Platinum, Amex Delta Platinum Business, Chase Freedom Flex, and Chase Freedom Unlimited.
- **Card carousel reorder**: grouped by AMEX personal → Capital One personal → other personal → business.

## New event taxonomy

| Event name | Payload |
|---|---|
| `Subscribe Click` | `{ interest }` |
| `Credit Card Apply` | `{ card }` |
| `Tool Click` | `{ tool }` |
| `Smart Search` | `{ query }` (truncated to 100 chars) |
| `Nav Tab Click` | `{ tab }` |
| `Logo Click` | — |
| `Banner CTA Click` | `{ section }` |
| `Category Click` | `{ category }` |
| `Blog Card Click` | `{ post }` |
| `YouTube Video Click` | `{ video }` |
| `YouTube Channel Click` | — |
| `Consultation Click` | — |

Notable side effects of consolidation:
- `credit-card-apply-clicked` + `${cardName}-apply-clicked` → single `Credit Card Apply` event (also removes a `data-umami-event` that was double-counting per-card clicks via Umami's declarative handler).
- `smart-search-btn-click` + `${query}-SMART-SEARCH` → single `Smart Search` event (the old pattern created unbounded cardinality with one event name per unique query).
- Nav bar: 5 `* Tab Selected` events → one `Nav Tab Click` + `tab` property; desktop logo gets its own `Logo Click`.

## Test plan

- [ ] `npm run dev`, submit the newsletter form — verify Subscribe button gates on interest, Listmonk POST body is unchanged, and umami fires `Subscribe Click` with `{ interest }`.
- [ ] Click an Apply button on a credit card — verify exactly **one** umami request (`Credit Card Apply` + `{ card }`) and referral opens in a new tab.
- [ ] Click each nav tab + the desktop logo — verify `Nav Tab Click` with correct `tab` property, logo fires `Logo Click`.
- [ ] Click banner Programming/Credit Cards links, a category chip, a blog card, a YouTube card — verify drilldown payloads populate in Umami's Properties view.
- [ ] Verify refreshed referral links open the correct signup pages.
- [ ] Verify credit card carousel order matches the new grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)