### PR TITLE
UI: uniform credit card carousel items + add Bilt Palladium

### DIFF
--- a/components/CreditCardItem.js
+++ b/components/CreditCardItem.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Heading, VStack, Flex, Spacer, Button, Text } from "@chakra-ui/react";
+import { Heading, Flex, Button, Text } from "@chakra-ui/react";
 import { colors } from "../lib/constants";
 
 export default function CreditCardItem({
@@ -22,37 +22,48 @@ export default function CreditCardItem({
   return (
     <Flex
       flexDirection="column"
+      alignItems="center"
       bg={colors.bgCard}
-      padding="2vw"
-      borderRadius="2vw"
-      justifyContent="space-between"
-      alignItems="stretch"
+      padding={{ base: 5, md: 6 }}
+      borderRadius="2xl"
+      width={{ base: "260px", md: "300px" }}
+      minHeight={{ base: "370px", md: "400px" }}
+      gap={4}
     >
-      <VStack>
-        <Image width={200} height={80} src={imageURL} alt="Credit Card Image" />
-        <Heading size="md" color={colors.accentGreen}>
-          {cardName}
-        </Heading>
-        <Spacer />
-        <Text whiteSpace="pre-line" color={colors.textLight}>
-          {cardDescription}
-        </Text>
-        <Spacer />
-
-        <Link href={referralURL}>
-          <Button
-            bg={colors.accentYellow}
-            color={colors.textDark}
-            size="sm"
-            fontSize="lg"
-            fontWeight="bold"
-            _hover={{ cursor: "pointer" }}
-            onClick={handleClick}
-          >
-            <Text fontSize={"sm"}>Apply</Text>
-          </Button>
-        </Link>
-      </VStack>
+      <Image width={200} height={80} src={imageURL} alt="Credit Card Image" />
+      <Heading
+        size="sm"
+        color={colors.accentGreen}
+        textAlign="center"
+        whiteSpace="normal"
+        noOfLines={2}
+        minHeight="3em"
+      >
+        {cardName}
+      </Heading>
+      <Text
+        color={colors.textLight}
+        textAlign="center"
+        fontSize="sm"
+        whiteSpace="normal"
+        noOfLines={5}
+        flex="1"
+      >
+        {cardDescription}
+      </Text>
+      <Link href={referralURL} style={{ marginTop: "auto" }}>
+        <Button
+          bg={colors.accentYellow}
+          color={colors.textDark}
+          size="sm"
+          fontSize="lg"
+          fontWeight="bold"
+          _hover={{ cursor: "pointer" }}
+          onClick={handleClick}
+        >
+          <Text fontSize={"sm"}>Apply</Text>
+        </Button>
+      </Link>
     </Flex>
   );
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -49,6 +49,12 @@ export const creditCards = [
     referralKey: "amexGold",
   },
   {
+    imageURL: `${CDN_BASE_URL}/credit-cards-photos/bilt-palladium.png`,
+    cardName: "Bilt Palladium",
+    cardDescription: "2X on Everything! Up to 1.25X on Rent & Mortgage! $400 Hotel Credits! $200 Annual Bilt Cash! Priority Pass Lounge Access!",
+    referralKey: "biltPalladium",
+  },
+  {
     imageURL: `${CDN_BASE_URL}/credit-cards-photos/hilton-surpass.png`,
     cardName: "Hilton Surpass Card",
     cardDescription: "12X Hilton Purchases! 6X Restaurants, Groceries, & Gas! 130K Bonus Points!",

--- a/lib/referralLinks.js
+++ b/lib/referralLinks.js
@@ -76,12 +76,15 @@ const referralLinks = {
   citiCustomCash:
     "https://www.citi.com/credit-cards/citi-custom-cash-credit-card",
 
-  // Bilt Card
-  biltMastercard: "https://bilt.page/r/1YFG-4S1F",
+  // Bilt Card (legacy key; still referenced by older blog posts)
+  biltMastercard: "https://www.bilt.com/card?invite=P55NBEJQ",
 
   // Rakuten
   rakutenAmex: "https://r.imprint.co/d95jFB",
   rakutenPortal: "https://www.rakuten.com/r/JBNNVV?eeid=28187",
+
+  // Bilt Cards
+  biltPalladium: "https://www.bilt.com/card?invite=P55NBEJQ",
 
   // Other Referral Links
   chime: "https://www.chime.com/r/mdirtizahafiz/",

--- a/lib/toolLinks.js
+++ b/lib/toolLinks.js
@@ -52,6 +52,11 @@ const toolLinks = {
       description: "Favorite hotel card!",
       url: referralLinks.amexHiltonSurpass,
     },
+    {
+      name: "Bilt Palladium",
+      description: "Favorite 1-card setup!",
+      url: referralLinks.biltPalladium,
+    },
   ],
 
   Productivity: [


### PR DESCRIPTION
## Summary

- **Uniform card dimensions**: `CreditCardItem` is now a fixed-size flex column (260/300px wide, 370/400px min-height at base/md) with the Apply button pinned to the bottom via `margin-top: auto`. Every card in the Recommended Cards carousel now shares the same width, height, and CTA baseline regardless of name or description length.
- **Card name**: wraps to 2 lines with reserved height (`noOfLines={2}` + `minHeight="3em"`) so the description always starts at the same y-coordinate across cards. Heading stepped down to `size="sm"`.
- **New card**: Bilt Palladium, inserted right after Amex Gold in the carousel and added to the "Favorite Credit Cards" tool list with the blurb "Favorite 1-card setup!". Description summarizes the current public benefits (2X on everything, up to 1.25X on rent/mortgage, \$400 hotel credits, \$200 Bilt Cash, Priority Pass).
- **Referral link**: new \`biltPalladium\` key in \`lib/referralLinks.js\`; the legacy \`biltMastercard\` key (still used by 8 older blog posts) now points at the same updated URL.

## Test plan

- [ ] \`npm run dev\`, scroll to Recommended Cards — verify every card has identical width/height and every Apply button sits on the same baseline.
- [ ] Verify long-name cards (Amex Business Platinum, Amex Delta Platinum Business) wrap cleanly without overflowing.
- [ ] Confirm Bilt Palladium appears immediately after Amex Gold with correct image, description, and working Apply link.
- [ ] Click Apply on Bilt Palladium — confirm it opens the Bilt referral URL and umami fires \`Credit Card Apply\` with \`{ card: \"Bilt Palladium\" }\`.
- [ ] Visit /tools — confirm Bilt Palladium appears under "Favorite Credit Cards" with the correct link.
- [ ] Spot-check an older blog post referencing \`<ReferralLink card=\"biltMastercard\">\` — confirm it now resolves to the updated Bilt URL.
- [ ] Check mobile (~375px) and desktop (≥1280px) breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)