### PR TITLE
Use npm run build in deploy workflow to regenerate sitemap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,6 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             npm ci
-            npx next build
+            npm run build
             pm2 restart portfolio-website
             pm2 restart portfolio-backend


### PR DESCRIPTION
## Summary
- Deploy workflow was running `npx next build`, which bypasses npm's `postbuild` hook
- As a result, `next-sitemap` never ran in production and the deployed sitemap stayed frozen at April 11
- Switching to `npm run build` ensures `postbuild` (and therefore `next-sitemap`) runs on every deploy

## Test plan
- [ ] After merge, confirm the deploy succeeds
- [ ] Curl `https://irtizahafiz.com/sitemap-0.xml` and verify `Last-Modified` is current and the new bookstore post URL is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)